### PR TITLE
Add .rubocop.yml for Ruby style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,20 @@ A collection of style guides used at RentPath.
 
 # Editor Setup
 
+## Atom
+
+1. `apm install linter-rubocop`
+2. Configure linter-rubocop by editing ~/.atom/config.cson (choose Open Your Config in Atom menu)
+```shell
+'linter-rubocop':
+      'executablePath': null # rubocop path.
+```
+  - Run `which rubocop` to find the path, if you using rbenv run `rbenv which rubocop`
+
+**Note**: This plugin finds the nearest .rubocop.yml file and uses the --config command line argument to use that file, so you may not use the --config argument in the linter settings.
+
+(*Source Credit*: [https://atom.io/packages/linter-rubocop](https://atom.io/packages/linter-rubocop))
+
 ## Vim
 
 - add to `.vimrc`
@@ -12,4 +26,3 @@ A collection of style guides used at RentPath.
 - mappings
   - `nmap <Leader>r :echo @%\|RuboCop -a <CR>` " autofix current file
   - use `<Leader>ru` to lint the current file
-

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # Style Guides
 A collection of style guides used at RentPath.
+
+# Editor Setup
+
+## Vim
+
+- add to `.vimrc`
+  - [rubocop plugin](https://github.com/ngmy/vim-rubocop)
+  - `let g:vimrubocop_config = ~/source/style-guides/ruby/.rubocop.yml`
+  - see `:RuboCop -h` for usage
+- mappings
+  - `nmap <Leader>r :echo @%\|RuboCop -a <CR>` " autofix current file
+  - use `<Leader>ru` to lint the current file
+

--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@ A collection of style guides used at RentPath.
 - mappings
   - `nmap <Leader>r :echo @%\|RuboCop -a <CR>` " autofix current file
   - use `<Leader>ru` to lint the current file
+
+## Sublime
+
+[Setup Sublime](https://github.com/rentpath/style-guides/wiki/Setup-Sublime-Linter)

--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -98,14 +98,16 @@ Style/GuardClause:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals'
   Enabled: false
 
-# I think this cop prevents shadowing in constuctors. Our style guide allows
-# for shadowing when both the method and local variables are equivalent. This
-# happens in constructors.
-Lint/ShadowingOuterLocalVariable:
+Style/ParallelAssignment:
   Description: >-
-                 Do not use the same name as outer local variable
-                 for block arguments or block local variables.
+                  Check for simple usages of parallel assignment.
+                  It will only warn when the number of variables
+                  matches on both sides of the assignment.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#parallel-assignment'
   Enabled: false
+
+
+#################### Metrics ################################
 
 Metrics/LineLength:
   Description: 'Limit lines to a set number of characters.'
@@ -118,3 +120,78 @@ Metrics/ParameterLists:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#too-many-params'
   Enabled: true
   Max: 4
+
+Metrics/AbcSize:
+  Description: >-
+                 A calculated magnitude based on number of assignments,
+                 branches, and conditions.
+  Reference: 'http://c2.com/cgi/wiki?AbcMetric'
+  Enabled: false
+
+Metrics/ClassLength:
+  Description: 'Avoid classes longer than 100 lines of code.'
+  Enabled: false
+
+Metrics/ModuleLength:
+  Description: 'Avoid modules longer than 100 lines of code.'
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Description: >-
+                 A complexity metric that is strongly correlated to the number
+                 of test cases needed to validate a method.
+  Enabled: false
+
+Metrics/PerceivedComplexity:
+  Description: >-
+                 A complexity metric geared towards measuring complexity for a
+                 human reader.
+  Enabled: false
+
+
+#################### Lint ################################
+
+Lint/AmbiguousRegexpLiteral:
+  Description: >-
+                 Checks for ambiguous regexp literals in the first argument of
+                 a method invocation without parentheses.
+  Enabled: false
+
+Lint/AssignmentInCondition:
+  Description: "Don't use assignment in conditions."
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#safe-assignment-in-condition'
+  Enabled: false
+
+Lint/RequireParentheses:
+  Description: >-
+                 Use parentheses in the method call to avoid confusion
+                 about precedence.
+  Enabled: false
+
+# I think this cop prevents shadowing in constuctors. Our style guide allows
+# for shadowing when both the method and local variables are equivalent. This
+# happens in constructors.
+Lint/ShadowingOuterLocalVariable:
+  Description: >-
+                 Do not use the same name as outer local variable
+                 for block arguments or block local variables.
+  Enabled: false
+
+Lint/StringConversionInInterpolation:
+  Description: 'Checks for Object#to_s usage in string interpolation.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-to-s'
+  Enabled: false
+
+Lint/UnderscorePrefixedVariableName:
+  Description: 'Do not use prefix `_` for a variable that is used.'
+  Enabled: false
+
+Lint/UnusedBlockArgument:
+  Description: 'Checks for unused block arguments.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#underscore-unused-vars'
+  Enabled: false
+
+Lint/UnusedMethodArgument:
+  Description: 'Checks for unused method arguments.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#underscore-unused-vars'
+  Enabled: false

--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -1,0 +1,102 @@
+Style/Encoding:
+  Description: 'Use UTF-8 as the source file encoding.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#utf-8'
+  Enabled: true
+
+Style/SpaceInsideHashLiteralBraces:
+  Description: "Use spaces inside hash literal braces - or don't."
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
+  Enabled: false
+
+Style/Documentation:
+  Description: 'Document classes and non-namespace modules.'
+  Enabled: false
+
+Style/EmptyLines:
+  Description: "Don't use several empty lines in a row."
+  Enabled: false
+
+# While our style guide says to do this, RuboCop would flag zip codes in specs
+# if we enabled this cop. We don't want to add underscores to zip codes.
+Style/NumericLiterals:
+  Description: >-
+                 Add underscores to large numeric literals to improve their
+                 readability.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#underscores-in-numerics'
+  Enabled: false
+
+Style/ParenthesesAroundCondition:
+  Description: >-
+                 Don't use parentheses around the condition of an
+                 if/unless/while.
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-parens-if'
+  Enabled: true
+  AllowSafeAssignment: false
+
+# Our style guide says to favor #sprintf over #%, but it doesn't mention #format
+Style/FormatString:
+  Description: 'Enforce the use of Kernel#sprintf, Kernel#format or String#%.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#sprintf'
+  Enabled: false
+
+Style/EachWithObject:
+  Enabled: false
+
+Style/SymbolArray:
+  Description: 'Use %i or %I for arrays of symbols.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-i'
+  Enabled: true
+
+Style/RegexpLiteral:
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-r'
+  Enabled: false
+
+Style/DoubleNegation:
+  Description: 'Checks for uses of double negation (!!).'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-bang-bang'
+  Enabled: false
+
+Style/GuardClause:
+  Description: 'Check for conditionals that can be replaced with guard clauses'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals'
+  Enabled: false
+
+Style/InfiniteLoop:
+  Description: 'Use Kernel#loop for infinite loops.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#infinite-loop'
+  Enabled: false
+
+Style/LineEndConcatenation:
+  Description: >-
+                 Use \ instead of + or << to concatenate two string literals at
+                 line end.
+  Enabled: false
+
+Style/EmptyLinesAroundClassBody:
+  Description: 'Disallow empty lines around class body.'
+  Enabled: false
+
+Style/EmptyLinesAroundModuleBody:
+  Description: 'Disallow empty lines around module body.'
+  Enabled: false
+
+# I think this cop prevents shadowing in constuctors. Our style guide allows
+# for shadowing when both the method and local variables are equivalent. This
+# happens in constructors.
+Lint/ShadowingOuterLocalVariable:
+  Description: >-
+                 Do not use the same name as outer local variable
+                 for block arguments or block local variables.
+  Enabled: false
+
+Metrics/LineLength:
+  Description: 'Limit lines to a set number of characters.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#80-character-limits'
+  Enabled: true
+  Max: 100
+
+Metrics/ParameterLists:
+  Description: 'Avoid parameter lists longer than three or four parameters.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#too-many-params'
+  Enabled: true
+  Max: 4

--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -80,6 +80,24 @@ Style/EmptyLinesAroundModuleBody:
   Description: 'Disallow empty lines around module body.'
   Enabled: false
 
+Style/AccessorMethodName:
+  Description: 'Check the naming of accessor methods for get_/set_.'
+  Enabled: false
+
+Style/ClassCheck:
+  Description: 'Enforces consistent use of `Object#is_a?` or `Object#kind_of?`.'
+  Enabled: false
+
+Style/ClassVars:
+  Description: 'Avoid the use of class variables.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-class-vars'
+  Enabled: false
+
+Style/GuardClause:
+  Description: 'Check for conditionals that can be replaced with guard clauses'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals'
+  Enabled: false
+
 # I think this cop prevents shadowing in constuctors. Our style guide allows
 # for shadowing when both the method and local variables are equivalent. This
 # happens in constructors.


### PR DESCRIPTION
The `.rubocop.yml` file in this commit corresponds to our [Ruby style guide from the wiki]((https://github.com/rentpath/idg/wiki/Ruby-Style-Guide) as closely as I could make it. I commented where--and why--I chose not to enforce a few styles.