### PR TITLE
[MPN] [000000000] switched Atom instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,7 @@ A collection of style guides used at RentPath.
 # Editor Setup
 
 ## Atom
-
-1. `apm install linter-rubocop`
-2. Configure linter-rubocop by editing ~/.atom/config.cson (choose Open Your Config in Atom menu)
-```shell
-'linter-rubocop':
-      'executablePath': null # rubocop path.
-```
-  - Run `which rubocop` to find the path, if you using rbenv run `rbenv which rubocop`
-
-**Note**: This plugin finds the nearest .rubocop.yml file and uses the --config command line argument to use that file, so you may not use the --config argument in the linter settings.
-
-(*Source Credit*: [https://atom.io/packages/linter-rubocop](https://atom.io/packages/linter-rubocop))
+[Setup Atom](https://github.com/rentpath/style-guides/wiki/Setup-Atom-Linter)
 
 ## Vim
 


### PR DESCRIPTION
Switched the instructions for setting up linter-rubocop from the
generic ones that don't fully work with our development setup, to
the ones I created in the wiki that should fully work.