### PR TITLE
Disable performance cops.

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -206,49 +206,8 @@ Performance/CaseWhenSplat:
                   of the list of `when` branches.
   Enabled: false
 
-Performance/Count:
-  Description: >-
-                  Use `count` instead of `select...size`, `reject...size`,
-                  `select...count`, `reject...count`, `select...length`,
-                  and `reject...length`.
-  Enabled: false
-
-Performance/Detect:
-  Description: >-
-                  Use `detect` instead of `select.first`, `find_all.first`,
-                  `select.last`, and `find_all.last`.
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerabledetect-vs-enumerableselectfirst-code'
-  Enabled: false
-
 Performance/FixedSize:
   Description: 'Do not compute the size of statically sized objects except in constants'
-  Enabled: false
-
-Performance/FlatMap:
-  Description: >-
-                  Use `Enumerable#flat_map`
-                  instead of `Enumerable#map...Array#flatten(1)`
-                  or `Enumberable#collect..Array#flatten(1)`
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerablemaparrayflatten-vs-enumerableflat_map-code'
-  Enabled: false
-
-Performance/ReverseEach:
-  Description: 'Use `reverse_each` instead of `reverse.each`.'
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerablereverseeach-vs-enumerablereverse_each-code'
-  Enabled: false
-
-Performance/Sample:
-  Description: >-
-                  Use `sample` instead of `shuffle.first`,
-                  `shuffle.last`, and `shuffle[Fixnum]`.
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#arrayshufflefirst-vs-arraysample-code'
-  Enabled: false
-
-Performance/Size:
-  Description: >-
-                  Use `size` instead of `count` for counting
-                  the number of elements in `Array` and `Hash`.
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#arraycount-vs-arraysize-code'
   Enabled: false
 
 # #tr and #gsub work differently, even when the number of characters is the same.

--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -196,3 +196,67 @@ Lint/UnusedMethodArgument:
   Description: 'Checks for unused method arguments.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#underscore-unused-vars'
   Enabled: false
+
+
+##################### Performance #############################
+
+Performance/CaseWhenSplat:
+  Description: >-
+                  Place `when` conditions that use splat at the end
+                  of the list of `when` branches.
+  Enabled: false
+
+Performance/Count:
+  Description: >-
+                  Use `count` instead of `select...size`, `reject...size`,
+                  `select...count`, `reject...count`, `select...length`,
+                  and `reject...length`.
+  Enabled: false
+
+Performance/Detect:
+  Description: >-
+                  Use `detect` instead of `select.first`, `find_all.first`,
+                  `select.last`, and `find_all.last`.
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerabledetect-vs-enumerableselectfirst-code'
+  Enabled: false
+
+Performance/FixedSize:
+  Description: 'Do not compute the size of statically sized objects except in constants'
+  Enabled: false
+
+Performance/FlatMap:
+  Description: >-
+                  Use `Enumerable#flat_map`
+                  instead of `Enumerable#map...Array#flatten(1)`
+                  or `Enumberable#collect..Array#flatten(1)`
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerablemaparrayflatten-vs-enumerableflat_map-code'
+  Enabled: false
+
+Performance/ReverseEach:
+  Description: 'Use `reverse_each` instead of `reverse.each`.'
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerablereverseeach-vs-enumerablereverse_each-code'
+  Enabled: false
+
+Performance/Sample:
+  Description: >-
+                  Use `sample` instead of `shuffle.first`,
+                  `shuffle.last`, and `shuffle[Fixnum]`.
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#arrayshufflefirst-vs-arraysample-code'
+  Enabled: false
+
+Performance/Size:
+  Description: >-
+                  Use `size` instead of `count` for counting
+                  the number of elements in `Array` and `Hash`.
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#arraycount-vs-arraysize-code'
+  Enabled: false
+
+# #tr and #gsub work differently, even when the number of characters is the same.
+# Keep this disabled.
+Performance/StringReplacement:
+  Description: >-
+                  Use `tr` instead of `gsub` when you are replacing the same
+                  number of characters. Use `delete` instead of `gsub` when
+                  you are deleting characters.
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#stringgsub-vs-stringtr-code'
+  Enabled: false

--- a/ruby/style_guide.md
+++ b/ruby/style_guide.md
@@ -1741,19 +1741,125 @@ this rule only to arrays with two or more elements.
     ```
 * Use `fetch` with second argument to use a default value
 
-   ```Ruby
-   batman = { name: 'Bruce Wayne', is_evil: false }
+    ```Ruby
+    batman = { name: 'Bruce Wayne', is_evil: false }
 
-   # bad - if we just use || operator with falsy value we won't get the expected result
-   batman[:is_evil] || true # => true
+    # bad - if we just use || operator with falsy value we won't get the expected result
+    batman[:is_evil] || true # => true
 
-   # good - fetch work correctly with falsy values
-   batman.fetch(:is_evil, true) # => false
-   ```
+    # good - fetch work correctly with falsy values
+    batman.fetch(:is_evil, true) # => false
+    ```
 
 * Rely on the fact that as of Ruby 1.9 hashes are ordered.
 
 * Never modify a collection while traversing it.
+
+* Use `count` instead of `select...size`, `reject...size`,
+  `select...count`, `reject...count`, `select...length`,
+  and `reject...length`.
+
+    ```Ruby
+    # bad
+    [1, 2, 3].select { |e| e > 2 }.size
+    [1, 2, 3].reject { |e| e > 2 }.size
+    [1, 2, 3].select { |e| e > 2 }.length
+    [1, 2, 3].reject { |e| e > 2 }.length
+    [1, 2, 3].select { |e| e > 2 }.count { |e| e.odd? }
+    [1, 2, 3].reject { |e| e > 2 }.count { |e| e.even? }
+    array.select(&:value).count
+
+    # good
+    [1, 2, 3].count { |e| e > 2 }
+    [1, 2, 3].count { |e| e < 2 }
+    [1, 2, 3].count { |e| e > 2 && e.odd? }
+    [1, 2, 3].count { |e| e < 2 && e.even? }
+    Model.select('field AS field_one').count
+    Model.select(:value).count
+    ```
+
+* Use `detect` instead of `select.first`, `select.last`,
+  `find_all.first`, or `find_all.last`.
+
+    ```Ruby
+    # bad
+    [].select { |item| true }.first
+    [].select { |item| true }.last
+    [].find_all { |item| true }.first
+    [].find_all { |item| true }.last
+
+    # good
+    [].detect { |item| true }
+    [].reverse.detect { |item| true }
+    ```
+
+* Use `Enumerable#flat_map`
+  instead of `Enumerable#map...Array#flatten(1)`
+  or `Enumberable#collect..Array#flatten(1)`
+
+    ```Ruby
+    # bad
+    [1, 2, 3, 4].map { |e| [e, e] }.flatten(1)
+    [1, 2, 3, 4].collect { |e| [e, e] }.flatten(1)
+
+    # good
+    [1, 2, 3, 4].flat_map { |e| [e, e] }
+    [1, 2, 3, 4].map { |e| [e, e] }.flatten
+    [1, 2, 3, 4].collect { |e| [e, e] }.flatten
+    ```
+
+* Use `reverse_each` instead of `reverse.each`.
+
+    ```Ruby
+    # bad
+    [].reverse.each
+
+    # good
+    [].reverse_each
+    ```
+
+* Use `sample` instead of `shuffle.first`,
+  `shuffle.last`, and `shuffle[Fixnum]`.
+
+    ```Ruby
+    # bad
+    [1, 2, 3].shuffle.first
+    [1, 2, 3].shuffle.first(2)
+    [1, 2, 3].shuffle.last
+    [1, 2, 3].shuffle[2]
+    [1, 2, 3].shuffle[0, 2]    # sample(2) will do the same
+    [1, 2, 3].shuffle[0..2]    # sample(3) will do the same
+    [1, 2, 3].shuffle(random: Random.new).first
+
+    # good
+    [1, 2, 3].shuffle
+    [1, 2, 3].sample
+    [1, 2, 3].sample(3)
+    [1, 2, 3].shuffle[1, 3]    # sample(3) might return a longer Array
+    [1, 2, 3].shuffle[1..3]    # sample(3) might return a longer Array
+    [1, 2, 3].shuffle[foo, bar]
+    [1, 2, 3].shuffle(random: Random.new)
+    ```
+
+* Use `size` instead of `count` for counting
+  the number of elements in `Array` and `Hash`.
+
+    ```Ruby
+    # bad
+    [1, 2, 3].count
+
+    # bad
+    {a: 1, b: 2, c: 3}.count
+
+    # good
+    [1, 2, 3].size
+
+    # good
+    {a: 1, b: 2, c: 3}.size
+
+    # good
+    [1, 2, 3].count { |e| e > 2 }
+    ```
 
 ## Strings
 


### PR DESCRIPTION
Our style guide doesn't mention these. It is better to optimize for
readability up front, and tweak performance after profiling the app.