### PR TITLE
[MPN] Increase max line size to 120?

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -114,7 +114,7 @@ Metrics/LineLength:
   Description: 'Limit lines to a set number of characters.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#80-character-limits'
   Enabled: true
-  Max: 100
+  Max: 120
 
 Metrics/ParameterLists:
   Description: 'Avoid parameter lists longer than three or four parameters.'

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -29,7 +29,7 @@ Based on the [fantastic work](https://github.com/bbatsov/ruby-style-guide) by [B
 * Use `UTF-8` as the source file encoding.
 * Use YARD and its conventions for API documentation.  Don't put an
   empty line between the comment block and the `def`.
-* Limit lines to 100 characters.
+* Limit lines to 120 characters.
 * No trailing whitespace.
 * Use two **spaces** per indentation level. No hard tabs.
 


### PR DESCRIPTION
It seems many people expect the max line size to be 120. There are
many lines where a slight increase would remove a warning from rubocop
and I don't really see 120 as too long still.

What do other people think?