### PR TITLE
Wh add sass lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,36 @@
 # Style Guides
 A collection of style guides used at RentPath.
 
+## Lint config files
+### SASS
+  Uses node's sass-lint. Copy `css/.sass-lint.yml` to your project directory and change the src option to a glob that includes your `.scss` files. To run it, install sass-lint (`npm install sass-lint`) and run `sass-lint -v`. If there are any errors or warnings, they should show in your output. 
+  
+  To run with webpack, You'll need to add the configfile to your webpack file.
+   
+  ```javascript
+  module.exports = {
+    sasslint: {
+      configFlie: '.sass-lint.yml'
+    }
+  }
+  
+  ``` 
+  and then add it to your preloaders
+  
+  ```javascript
+  module: {
+    preLoaders: [
+      {
+        test: /\.scss?$/,
+        exclude: [/node_modules/],
+        loaders: ['sasslint'],
+        //this should change with your project and point to where your scss files are
+        include: path.join(__dirname, '../src')
+      }
+    ]
+  }
+  ```
+  
 ## Editor Setup
 
 - [Atom](https://github.com/rentpath/style-guides/wiki/Setup-Atom-Linter)

--- a/css/.sass-lint.yml
+++ b/css/.sass-lint.yml
@@ -1,0 +1,74 @@
+#########################
+## Sample Sass Lint File
+#########################
+# Linter Options
+options:
+  # Don't merge default rules
+  merge-default-rules: false
+  formatter: stylish 
+
+# File Options
+files:
+  include: './src/**/*.scss'
+  ignore:
+    - 'docker/'
+
+# Rule Configuration
+rules:
+  extends-before-mixins: 2
+  extends-before-declarations: 2
+  placeholder-in-extend: 2
+  brace-style: 
+    - 2
+    - 
+      style: '1tbs'
+    -
+      allow-single-line:
+        - false
+  space-before-brace: 
+    - 2
+    - true
+  space-after-colon: 
+    - 2
+    - true
+  single-line-per-selector: 
+    - 2
+    - true
+  mixins-before-declarations:
+    - 2
+    -
+      exclude:
+        - breakpoint
+        - mq
+  empty-line-between-blocks:
+    - 2
+    -
+      include:
+        - true
+  shorthand-values: 2
+  zero-unit: 2
+  nesting-depth:
+    - 1 
+    - 
+      max-depth: 
+        - 2
+  no-warn: 1
+  no-debug: 1
+  no-ids: 2
+  no-important: 2
+  hex-notation:
+    - 2
+    -
+      style: uppercase
+  indentation:
+    - 2
+    -
+      size: 2
+
+  property-sort-order:
+    - 1
+    -
+      order:
+        - display
+        - margin
+      ignore-custom-properties: true


### PR DESCRIPTION
Pr that has the sass linter. Only two rules that it doesn't enforce are
1) no css comments. This is because for some reason, for converting sass to css with webkit can cause our loader to break.
2) Shorthand for margins. There's currently no rule to enforce margin: 0 0 0 5px to margin-bottom: 5px.