### PR TITLE
Disable block length cop

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -222,3 +222,8 @@ Performance/StringReplacement:
                   you are deleting characters.
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#stringgsub-vs-stringtr-code'
   Enabled: false
+
+# Long blocks are already caught by the method length cop, this only causes an
+# offense for configuration blocks where its fine for the block to be very long
+Metrics/BlockLength:
+  Enabled: false


### PR DESCRIPTION
Metrics/BlockLength is pointless. We have Metrics/MethodLength which already catches this. In the event that its not in a method, its a configuration block and having it be very long is acceptable in that situation.

This came up because its a new cop in the new version of Rubocop.