### PR TITLE
Update Delimiter to keep current settings

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -1,6 +1,15 @@
 AllCops:
   TargetRubyVersion: 2.2
 
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    default: ()
+    '%r': '{}'
+    '%w': '()'
+    '%W': '()'
+    '%i': '()'
+    '%I': '()'
+
 Style/Encoding:
   Description: 'Use UTF-8 as the source file encoding.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#utf-8'


### PR DESCRIPTION
- prevent all existing repos that uses shared setup from breaking.

The Style Guide was changed to [prefer square brackets for word- and
symbol array literals] https://github.com/bbatsov/rubocop/issues/4039