### PR TITLE
remove encoding flag

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -52,11 +52,6 @@ Style/PercentLiteralDelimiters:
     '%i': '()'
     '%I': '()'
 
-Style/Encoding:
-  Description: 'Use UTF-8 as the source file encoding.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#utf-8'
-  Enabled: true
-
 Style/Documentation:
   Description: 'Document classes and non-namespace modules.'
   Enabled: false


### PR DESCRIPTION
Style/Encoding is enabled by default now, and the presence of this
setting is throwing errors blocking rubocop execution with newer
versions of rubocop

see:
https://github.com/bbatsov/rubocop/pull/4445