### PR TITLE
Extend method length limit from 10 (default) to 12

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -143,6 +143,12 @@ Metrics/LineLength:
   Enabled: true
   Max: 120
 
+Metrics/MethodLength:
+  Description: 'Limit methods to 12 lines.'
+  StyleGuide: 'https://github.com/rubocop-hq/ruby-style-guide#short-methods'
+  Enabled: true
+  Max: 12
+
 Metrics/ParameterLists:
   Description: 'Avoid parameter lists longer than three or four parameters.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#too-many-params'


### PR DESCRIPTION
There are a few methods in rnr_ui that are 11 lines long. I don't think these methods would benefit from extracting code into a separate method. I think 12 is a more reasonable hard limit.