### PR TITLE
Update .credo.exs

### DIFF
--- a/elixir/.credo.exs
+++ b/elixir/.credo.exs
@@ -19,8 +19,8 @@
         #
         # you can give explicit globs or simply directories
         # in the latter case `**/*.{ex,exs}` will be used
-        included: ["lib/", "src/", "web/", "apps/"],
-        excluded: [~r"/_build/", ~r"/deps/"]
+        included: ["lib/", "src/", "test/", "web/", "apps/"],
+        excluded: [~r"/_build/", ~r"/deps/", ~r"/node_modules/"]
       },
       #
       # If you create your own checks, you must specify the source files for
@@ -30,6 +30,14 @@
       # Credo automatically checks for updates, like e.g. Hex does.
       # You can disable this behaviour below:
       check_for_updates: true,
+      #
+      # If you want to enforce a style guide and need a more traditional linting
+      # experience, you can change `strict` to `true` below:
+      strict: true,
+      #
+      # If you want to use uncolored output by default, you can change `color`
+      # to `false` below:
+      color: true,
       #
       # You can customize the parameters of any check by adding a second element
       # to the tuple.
@@ -41,6 +49,8 @@
       checks: [
         {Credo.Check.Consistency.ExceptionNames},
         {Credo.Check.Consistency.LineEndings},
+        {Credo.Check.Consistency.MultiAliasImportRequireUse},
+        {Credo.Check.Consistency.ParameterPatternMatching},
         {Credo.Check.Consistency.SpaceAroundOperators},
         {Credo.Check.Consistency.SpaceInParentheses},
         {Credo.Check.Consistency.TabsOrSpaces},
@@ -54,7 +64,7 @@
         # If you don't want the `setup` and `test` macro calls in ExUnit tests
         # or the `schema` macro in Ecto schemas to trigger DuplicatedCode, just
         # set the `excluded_macros` parameter to `[:schema, :setup, :test]`.
-        {Credo.Check.Design.DuplicatedCode, excluded_macros: []},
+        {Credo.Check.Design.DuplicatedCode, excluded_macros: [], exit_status: 0},
 
         # You can also customize the exit_status of each check.
         # If you don't want TODO comments to cause `mix credo` to fail, just
@@ -62,43 +72,64 @@
         {Credo.Check.Design.TagTODO, exit_status: 2},
         {Credo.Check.Design.TagFIXME},
 
+        {Credo.Check.Readability.AliasOrder},
         {Credo.Check.Readability.FunctionNames},
         {Credo.Check.Readability.LargeNumbers},
-        {Credo.Check.Readability.MaxLineLength, false},
+        {Credo.Check.Readability.MaxLineLength, max_length: 120},
         {Credo.Check.Readability.ModuleAttributeNames},
         {Credo.Check.Readability.ModuleDoc},
         {Credo.Check.Readability.ModuleNames},
+        {Credo.Check.Readability.ParenthesesInCondition, false},
+        {Credo.Check.Readability.ParenthesesOnZeroArityDefs},
         {Credo.Check.Readability.PredicateFunctionNames},
+        {Credo.Check.Readability.PreferImplicitTry, exit_status: 0},
+        # {Credo.Check.Readability.PreferUnquotedAtoms}, # There is a bug in this Credo check in right now.
+        {Credo.Check.Readability.RedundantBlankLines},
+        {Credo.Check.Readability.Semicolons},
+        {Credo.Check.Readability.SinglePipe},
+        {Credo.Check.Readability.SpaceAfterCommas},
+        {Credo.Check.Readability.Specs},
+        {Credo.Check.Readability.StringSigils, false},
         {Credo.Check.Readability.TrailingBlankLine},
         {Credo.Check.Readability.TrailingWhiteSpace},
         {Credo.Check.Readability.VariableNames},
 
         {Credo.Check.Refactor.ABCSize},
-        # {Credo.Check.Refactor.CaseTrivialMatches}, # deprecated in 0.4.0
-        {Credo.Check.Refactor.CondStatements},
-        {Credo.Check.Refactor.FunctionArity},
-        {Credo.Check.Refactor.MatchInCondition},
-        {Credo.Check.Refactor.PipeChainStart, false},
+        {Credo.Check.Refactor.AppendSingleItem, exit_status: 0},
+        {Credo.Check.Refactor.CaseTrivialMatches, false},
+        {Credo.Check.Refactor.CondStatements, false},
         {Credo.Check.Refactor.CyclomaticComplexity},
+        {Credo.Check.Refactor.DoubleBooleanNegation},
+        {Credo.Check.Refactor.FunctionArity, max_arity: 6},
+        {Credo.Check.Refactor.LongQuoteBlocks, false},
+        {Credo.Check.Refactor.MapInto},
+        {Credo.Check.Refactor.MatchInCondition},
         {Credo.Check.Refactor.NegatedConditionsInUnless},
         {Credo.Check.Refactor.NegatedConditionsWithElse},
         {Credo.Check.Refactor.Nesting},
+        {Credo.Check.Refactor.PerceivedComplexity, false},
+        {Credo.Check.Refactor.PipeChainStart,
+         excluded_argument_types: [:atom, :binary, :fn, :keyword], excluded_functions: []},
+        {Credo.Check.Refactor.VariableRebinding},
         {Credo.Check.Refactor.UnlessWithElse},
 
+        {Credo.Check.Warning.BoolOperationOnSameValues},
+        {Credo.Check.Warning.ExpensiveEmptyEnumCheck},
         {Credo.Check.Warning.IExPry},
         {Credo.Check.Warning.IoInspect},
-        {Credo.Check.Warning.NameRedeclarationByAssignment},
-        {Credo.Check.Warning.NameRedeclarationByCase},
-        {Credo.Check.Warning.NameRedeclarationByDef},
-        {Credo.Check.Warning.NameRedeclarationByFn},
+        {Credo.Check.Warning.LazyLogging, false},
+        {Credo.Check.Warning.MapGetUnsafePass},
         {Credo.Check.Warning.OperationOnSameValues},
-        {Credo.Check.Warning.BoolOperationOnSameValues},
+        {Credo.Check.Warning.OperationWithConstantResult},
+        {Credo.Check.Warning.RaiseInsideRescue},
         {Credo.Check.Warning.UnusedEnumOperation},
+        {Credo.Check.Warning.UnusedFileOperation},
         {Credo.Check.Warning.UnusedKeywordOperation},
         {Credo.Check.Warning.UnusedListOperation},
+        {Credo.Check.Warning.UnusedPathOperation},
+        {Credo.Check.Warning.UnusedRegexOperation},
         {Credo.Check.Warning.UnusedStringOperation},
         {Credo.Check.Warning.UnusedTupleOperation},
-        {Credo.Check.Warning.OperationWithConstantResult},
 
         # Custom checks can be created using `mix credo.gen.check`.
         #

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -8,21 +8,22 @@
 
 # Style Guide
 
-RentPath uses [René Föhring's](https://github.com/rrrene) Elixir Style Guide,
-which can be found [here](https://github.com/rrrene/elixir-style-guide).
+RentPath uses Christopher Adams's Elixir Style Guide,
+which can be found [here](https://github.com/christopheradams/elixir_style_guide).
 
 # Code Analysis
 
 RentPath uses [Credo](https://github.com/rrrene/credo) for code analysis. See
-`.credo.exs` for an example `Credo` config file.
+[`.credo.exs`](.credo.exs) for an example `Credo` config file.
 
 # Elixir Installation and Version Management
 
 A popular, though not required, option for installing and managing multiple
-versions of Elixir is to use [exenv][1] and [elixir-build][2].
+versions of Elixir is to use [exenv][1] and [elixir-build][2]. Other options
+are [kiex][3] and [asdf-elixir][4].
 
-Follow the installation instructions for those two applications. Then install
-the elixir version in use for the application available in the
+Follow the installation instructions for those two first applications. Then
+install the elixir version in use for the application available in the
 `.exenv-version` file at the root of the project:
 
     $ exenv install <a.b.c>
@@ -46,3 +47,5 @@ version based on the `.exenv-version` file in the project you are working on.
 
 [1]:https://github.com/mururu/exenv
 [2]:https://github.com/mururu/elixir-build
+[3]:https://github.com/taylor/kiex
+[4]:https://github.com/asdf-vm/asdf-elixir


### PR DESCRIPTION
[Card](https://rentpath.leankit.com/card/697057859)

* Add new Credo checks
* Enable disabled checks that reflect [Christopher Adams's style  guide](https://github.com/christopheradams/elixir_style_guide).
* Set the duplicate code Credo check not to fail a build. It's possible  to DRY code prematurely. Creating an abstraction for code that is  structurally identical, but is not the same for essential reasons,  could leave us with a faulty abstraction.
* Check test files. These are an important part of our codebase, and  should be as clean as our application code.
* Exclude the `node_modules/` directory
* Enforce line length. I think we've been doing it in some cases  already, and this will help our code readability.
* Require `@spec` for functions. We've already been doing this  sometimes, so this check just codifies our current practice. Adding  `@spec` will  help us leverage dialyzer, as well as serve as code documentation.
* Remove `Credo.Check.Warning.NameRedeclarationBy*` checks that no  longer exist in Credo.
* Disable `Credo.Check.Refactor.CondStatements`. A `cond` statement is sometimes more concise than `if/then` code.

Explanations of checks are in the beginning of each check file. You can find the check files [here](https://github.com/rrrene/credo/tree/master/lib/credo/check).