### PR TITLE
Update Elixir alias check

### DIFF
--- a/elixir/.credo.exs
+++ b/elixir/.credo.exs
@@ -57,7 +57,7 @@
 
         # For some checks, like AliasUsage, you can only customize the priority
         # Priority values are: `low, normal, high, higher`
-        {Credo.Check.Design.AliasUsage, priority: :low},
+        {Credo.Check.Design.AliasUsage, if_called_more_often_than: 2, priority: :low},
 
         # For others you can set parameters
 


### PR DESCRIPTION
This eases up the requirement on aliasing modules somewhat. If you use
some code like `X.Y` in a file once or twice, Credo won't tell you to
alias it. If you use it more than twice, Credo will flag the issue.