### PR TITLE
Too many complaints about writing specs

### DIFF
--- a/elixir/.credo.exs
+++ b/elixir/.credo.exs
@@ -88,7 +88,7 @@
         {Credo.Check.Readability.Semicolons},
         {Credo.Check.Readability.SinglePipe},
         {Credo.Check.Readability.SpaceAfterCommas},
-        {Credo.Check.Readability.Specs},
+        {Credo.Check.Readability.Specs, false},
         {Credo.Check.Readability.StringSigils, false},
         {Credo.Check.Readability.TrailingBlankLine},
         {Credo.Check.Readability.TrailingWhiteSpace},


### PR DESCRIPTION
Remove the check due to complaints.

Let's use the PR to put this conversation to rest once and for all.  Either we require the check and deal with it or we remove it, but we can't continue to spend hours debating it.