### PR TITLE
Update credo config for Elixir 1.9

### DIFF
--- a/elixir/.credo.exs
+++ b/elixir/.credo.exs
@@ -102,7 +102,7 @@
         {Credo.Check.Refactor.DoubleBooleanNegation},
         {Credo.Check.Refactor.FunctionArity, max_arity: 6},
         {Credo.Check.Refactor.LongQuoteBlocks, false},
-        {Credo.Check.Refactor.MapInto},
+        {Credo.Check.Refactor.MapInto, false},
         {Credo.Check.Refactor.MatchInCondition},
         {Credo.Check.Refactor.NegatedConditionsInUnless},
         {Credo.Check.Refactor.NegatedConditionsWithElse},


### PR DESCRIPTION
[Card](https://rentpath.atlassian.net/browse/SRV-1241)

From https://github.com/rrrene/credo/blob/master/lib/credo/check/refactor/map_into.ex:

> only avaible in Elixir < 1.8 since performance improvements have since made this check obsolete

So we can remove this check since everything is being migrated to Elixir 1.9.