### PR TITLE
Update renamed rubocop rule

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -200,7 +200,7 @@ Lint/ShadowingOuterLocalVariable:
                  for block arguments or block local variables.
   Enabled: false
 
-Lint/StringConversionInInterpolation:
+Lint/RedundantStringCoercion:
   Description: 'Checks for Object#to_s usage in string interpolation.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-to-s'
   Enabled: false


### PR DESCRIPTION
[card](https://rentpath.atlassian.net/browse/SRV-1826)

Error: The `Lint/StringConversionInInterpolation` cop has been renamed to `Lint/RedundantStringCoercion`.