### PR TITLE
feat!: Run credo on test .ex and .exs files

### DIFF
--- a/elixir/.credo.exs
+++ b/elixir/.credo.exs
@@ -19,7 +19,7 @@
         #
         # you can give explicit globs or simply directories
         # in the latter case `**/*.{ex,exs}` will be used
-        included: ["lib/", "src/", "test/", "web/", "apps/"],
+        included: ["lib/", "src/", "web/", "apps/", "test/**/*.{ex,exs}"],
         excluded: [~r"/_build/", ~r"/deps/", ~r"/node_modules/"]
       },
       #


### PR DESCRIPTION
We often make simple style guide violations in our test code that can be
caught by Credo. Running Credo for tests should result in better
formatting for our test code.