### PR TITLE
Enforce order of module attributes for Elixir projects

### DIFF
--- a/elixir/.credo.exs
+++ b/elixir/.credo.exs
@@ -79,6 +79,8 @@
         {Credo.Check.Readability.ModuleAttributeNames},
         {Credo.Check.Readability.ModuleDoc},
         {Credo.Check.Readability.ModuleNames},
+        {Credo.Check.Readability.StrictModuleLayout,
+          order: ~w/shortdoc moduledoc behaviour use import require alias module_attribute defstruct type typep callback macrocallback optional_callbacks/a},
         {Credo.Check.Readability.ParenthesesInCondition, false},
         {Credo.Check.Readability.ParenthesesOnZeroArityDefs},
         {Credo.Check.Readability.PredicateFunctionNames},


### PR DESCRIPTION
[Card](https://rentpath.atlassian.net/browse/SRV-2525)

Enforce the module attribute order specified by the style guide we use - https://github.com/christopheradams/elixir_style_guide#modules

https://hexdocs.pm/credo/Credo.Check.Readability.StrictModuleLayout.html