### PR TITLE
Remove credo check that is no longer compatible

### DIFF
--- a/elixir/.credo.exs
+++ b/elixir/.credo.exs
@@ -86,7 +86,6 @@
         {Credo.Check.Readability.ParenthesesOnZeroArityDefs},
         {Credo.Check.Readability.PredicateFunctionNames},
         {Credo.Check.Readability.PreferImplicitTry, exit_status: 0},
-        {Credo.Check.Readability.PreferUnquotedAtoms},
         {Credo.Check.Readability.RedundantBlankLines},
         {Credo.Check.Readability.Semicolons},
         {Credo.Check.Readability.SinglePipe},


### PR DESCRIPTION
[Card](https://rentpath.atlassian.net/browse/SRV-5972)

Docs state it requires < 1.7.0-dev

I mistakenly enabled it in my previous PR.